### PR TITLE
Add -v flag that causes fs events to be logged

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage
       -help=false: print this help text
       -i="": comma-separated list of files to ignore
       -stdin=false: read list of files to track from stdin, not the command-line
+      -v=false: verbose output
       -w=false: wait for the command to finish and do not attempt to kill it
 
 Compared to other tools

--- a/justrun.go
+++ b/justrun.go
@@ -22,6 +22,7 @@ var (
 	stdin          = flag.Bool("stdin", false, "read list of files to track from stdin, not the command-line")
 	waitForCommand = flag.Bool("w", false, "wait for the command to finish and do not attempt to kill it")
 	delayDur       = flag.Duration("delay", 750*time.Millisecond, "the time to wait between runs of the command if many fs events occur")
+	verbose        = flag.Bool("v", false, "verbose output")
 )
 
 func usage() {
@@ -217,6 +218,9 @@ func listenForEvents(w *fsnotify.Watcher, cmdCh chan time.Time, ignorer *ignorer
 		case ev := <-w.Event:
 			if ignorer.IsIgnored(ev.Name) {
 				continue
+			}
+			if *verbose {
+				log.Printf("file changed: %s", ev)
 			}
 			cmdCh <- time.Now()
 		case err := <-w.Error:


### PR DESCRIPTION
Helpful for hunting down unexpected restarts (in my case, flymake's the culprit).

```
2013/11/24 01:21:37 file changed: "web/flymake_users.go": CREATE
2013/11/24 01:21:37 file changed: "web/flymake_users.go": DELETE
2013/11/24 01:21:37 terminating command 897
2013/11/24 01:21:37 running go build && ./server config.json
2013/11/24 01:21:45 file changed: "web/users.go": MODIFY
2013/11/24 01:21:45 terminating command 1596
2013/11/24 01:21:45 running go build && ./server config.json
```
