### PR TITLE
Fix a compiler error.

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -61,7 +61,6 @@ func watch(inputPaths, ignoredPaths []string, cmdCh chan<- time.Time) (*fsnotify
 			includedHiddenFiles[fullPath] = true
 		}
 	}
-	ig := &smartIgnorer{includedHiddenFiles: includedHiddenFiles, ui: ui}
 
 	// Folks might want to watch only "foobar" but their tooling moves
 	// foobar away and then back (like vim). This will cause the watch


### PR DESCRIPTION
This lil' guy was declared twice and caused a compiler error on `go get`.

```
$ go get github.com/jmhodges/justrun
# github.com/jmhodges/justrun
projects/golang/src/github.com/jmhodges/justrun/watch.go:87: no new variables on left side of :=
```