### PR TITLE
handle data race on interrupt by creating reloader

### DIFF
--- a/cmdwrap.go
+++ b/cmdwrap.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
+	"time"
 )
 
 type cmdWrapper struct {
-	*sync.Mutex
 	command string
 	cmd     *exec.Cmd
 }
@@ -18,8 +20,6 @@ type cmdWrapper struct {
 // sets it as the wrapped command. If exec.Cmd.Start returns an error, the
 // last wrapped cmd will be left in place.
 func (cw *cmdWrapper) Start() error {
-	cw.Lock()
-	defer cw.Unlock()
 	cmd := exec.Command("bash", "-c", *command)
 	// Necessary so that the SIGTERM's in Terminate will traverse down to the
 	// the child processes in the bash command above.
@@ -36,8 +36,6 @@ func (cw *cmdWrapper) Start() error {
 }
 
 func (cw *cmdWrapper) Terminate() error {
-	cw.Lock()
-	defer cw.Unlock()
 	if cw.cmd == nil {
 		return errors.New("not started")
 	}
@@ -50,8 +48,116 @@ func (cw *cmdWrapper) Terminate() error {
 }
 
 func (cw *cmdWrapper) Wait() error {
-	cw.Lock()
-	cmd := cw.cmd
-	cw.Unlock()
-	return cmd.Wait()
+	return cw.cmd.Wait()
+}
+
+type cmdReloader struct {
+	cond           *sync.Cond
+	waitErr        error
+	waitFinished   bool
+	reloadGen      int
+	waitForCommand bool
+	preventReloads bool
+	command        string
+	cmd            *cmdWrapper
+}
+
+// Reload stops the currently running process started by a previous Reload (if
+// called) and starts a new one. If Terminate has been previously called, it
+// will do nothing.
+func (cs *cmdReloader) Reload() {
+	cs.cond.L.Lock()
+	defer cs.cond.L.Unlock()
+
+	if cs.preventReloads {
+		// unable to reload the command because we are stopping but we don't
+		// want to have the main goroutine error out.
+		return
+	}
+
+	if cs.cmd != nil {
+		cs.terminate()
+	}
+
+	log.Printf("running '%s'\n", cs.command)
+	cs.cmd = &cmdWrapper{command: cs.command}
+
+	err := cs.cmd.Start()
+	if err != nil {
+		log.Printf("command failed: %s", err)
+		return
+	}
+	cs.reloadGen++
+
+	go func(cmd *exec.Cmd, cmdGen int) {
+		err := cmd.Wait()
+		cs.cond.L.Lock()
+		defer cs.cond.L.Unlock()
+		if cs.reloadGen != cmdGen {
+			panic(fmt.Sprintf("justrun: interal assertion failure: want command generation %d, got generation %d. Please file a ticket.", cmdGen, cs.reloadGen))
+		}
+		cs.waitErr = err
+		cs.waitFinished = true
+		cs.cond.Broadcast()
+	}(cs.cmd.cmd, cs.reloadGen)
+
+	if cs.waitForCommand {
+		err := <-cs.waitChan()
+		if err != nil {
+			log.Printf("command finished with error: %s", err)
+		}
+	}
+	return
+}
+
+// Terminate shuts down the command process and silently prevents Reload from
+// actually reloading. It will not return until the Wait of process created by
+// the cmdReloader has finished. This will never return if the process is hung.
+func (cs *cmdReloader) Terminate() {
+	cs.cond.L.Lock()
+	cs.preventReloads = true
+	cs.terminate()
+	cs.cond.L.Unlock()
+	// The read of this channel is deliberately left outside of the lock.
+	<-cs.waitChan()
+}
+
+func (cs *cmdReloader) terminate() {
+	err := cs.cmd.Terminate()
+	if err == syscall.ESRCH {
+		return
+	}
+
+	done := cs.waitChan()
+	// Done is sent to after the command's Wait call returns. But it's really a
+	// latency optimization (or spin-loop prevention) over polling the process
+	// with Terminate until the process stops existing (when syscall.ESRCH
+	// will be returned).
+	for err != syscall.ESRCH {
+		select {
+		case <-done:
+			break
+		case <-time.After(50 * time.Millisecond):
+			err = cs.cmd.Terminate()
+		}
+	}
+	msg := "terminating current command"
+	if *verbose {
+		msg += fmt.Sprintf(" %d", cs.cmd.cmd.Process.Pid)
+	}
+	log.Println(msg)
+}
+
+func (cs *cmdReloader) waitChan() <-chan error {
+	done := make(chan error, 1)
+	go func(done chan<- error) {
+		cs.cond.L.Lock()
+		for !cs.waitFinished {
+			cs.cond.Wait()
+		}
+		err := cs.waitErr
+		cs.cond.L.Unlock()
+		done <- err
+	}(done)
+	return done
 }

--- a/watch.go
+++ b/watch.go
@@ -118,9 +118,14 @@ func listenForEvents(w *fsnotify.Watcher, cmdCh chan<- event, ignorer Ignorer) {
 				Time:  time.Now(),
 				Event: ev,
 			}
-		case err := <-w.Errors:
+		case err, ok := <-w.Errors:
+			if !ok {
+				close(cmdCh)
+				return
+			}
 			// w.Close causes this.
 			if err == nil {
+				close(cmdCh)
 				return
 			}
 			log.Println("watch error:", err)


### PR DESCRIPTION
This cmdReloader does a better job of tracking the state of the process started
by justrun than previous code. It's main purpose here is to prevent reloads (new
process creation) when the user attempts to interrupt the justrun process (with
`ctrl-C` or similar signals).

Fixes #15