### PR TITLE
Revert "handle data race on interrupt by creating reloader (#18)"

### DIFF
--- a/cmdwrap.go
+++ b/cmdwrap.go
@@ -2,16 +2,14 @@ package main
 
 import (
 	"errors"
-	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
-	"time"
 )
 
 type cmdWrapper struct {
+	*sync.Mutex
 	command string
 	cmd     *exec.Cmd
 }
@@ -20,6 +18,8 @@ type cmdWrapper struct {
 // sets it as the wrapped command. If exec.Cmd.Start returns an error, the
 // last wrapped cmd will be left in place.
 func (cw *cmdWrapper) Start() error {
+	cw.Lock()
+	defer cw.Unlock()
 	cmd := exec.Command("bash", "-c", *command)
 	// Necessary so that the SIGTERM's in Terminate will traverse down to the
 	// the child processes in the bash command above.
@@ -36,6 +36,8 @@ func (cw *cmdWrapper) Start() error {
 }
 
 func (cw *cmdWrapper) Terminate() error {
+	cw.Lock()
+	defer cw.Unlock()
 	if cw.cmd == nil {
 		return errors.New("not started")
 	}
@@ -48,116 +50,8 @@ func (cw *cmdWrapper) Terminate() error {
 }
 
 func (cw *cmdWrapper) Wait() error {
-	return cw.cmd.Wait()
-}
-
-type cmdReloader struct {
-	cond           *sync.Cond
-	waitErr        error
-	waitFinished   bool
-	reloadGen      int
-	waitForCommand bool
-	preventReloads bool
-	command        string
-	cmd            *cmdWrapper
-}
-
-// Reload stops the currently running process started by a previous Reload (if
-// called) and starts a new one. If Terminate has been previously called, it
-// will do nothing.
-func (cs *cmdReloader) Reload() {
-	cs.cond.L.Lock()
-	defer cs.cond.L.Unlock()
-
-	if cs.preventReloads {
-		// unable to reload the command because we are stopping but we don't
-		// want to have the main goroutine error out.
-		return
-	}
-
-	if cs.cmd != nil {
-		cs.terminate()
-	}
-
-	log.Printf("running '%s'\n", cs.command)
-	cs.cmd = &cmdWrapper{command: cs.command}
-
-	err := cs.cmd.Start()
-	if err != nil {
-		log.Printf("command failed: %s", err)
-		return
-	}
-	cs.reloadGen++
-
-	go func(cmd *exec.Cmd, cmdGen int) {
-		err := cmd.Wait()
-		cs.cond.L.Lock()
-		defer cs.cond.L.Unlock()
-		if cs.reloadGen != cmdGen {
-			panic(fmt.Sprintf("justrun: interal assertion failure: want command generation %d, got generation %d. Please file a ticket.", cmdGen, cs.reloadGen))
-		}
-		cs.waitErr = err
-		cs.waitFinished = true
-		cs.cond.Broadcast()
-	}(cs.cmd.cmd, cs.reloadGen)
-
-	if cs.waitForCommand {
-		err := <-cs.waitChan()
-		if err != nil {
-			log.Printf("command finished with error: %s", err)
-		}
-	}
-	return
-}
-
-// Terminate shuts down the command process and silently prevents Reload from
-// actually reloading. It will not return until the Wait of process created by
-// the cmdReloader has finished. This will never return if the process is hung.
-func (cs *cmdReloader) Terminate() {
-	cs.cond.L.Lock()
-	cs.preventReloads = true
-	cs.terminate()
-	cs.cond.L.Unlock()
-	// The read of this channel is deliberately left outside of the lock.
-	<-cs.waitChan()
-}
-
-func (cs *cmdReloader) terminate() {
-	err := cs.cmd.Terminate()
-	if err == syscall.ESRCH {
-		return
-	}
-
-	done := cs.waitChan()
-	// Done is sent to after the command's Wait call returns. But it's really a
-	// latency optimization (or spin-loop prevention) over polling the process
-	// with Terminate until the process stops existing (when syscall.ESRCH
-	// will be returned).
-	for err != syscall.ESRCH {
-		select {
-		case <-done:
-			break
-		case <-time.After(50 * time.Millisecond):
-			err = cs.cmd.Terminate()
-		}
-	}
-	msg := "terminating current command"
-	if *verbose {
-		msg += fmt.Sprintf(" %d", cs.cmd.cmd.Process.Pid)
-	}
-	log.Println(msg)
-}
-
-func (cs *cmdReloader) waitChan() <-chan error {
-	done := make(chan error, 1)
-	go func(done chan<- error) {
-		cs.cond.L.Lock()
-		for !cs.waitFinished {
-			cs.cond.Wait()
-		}
-		err := cs.waitErr
-		cs.cond.L.Unlock()
-		done <- err
-	}(done)
-	return done
+	cw.Lock()
+	cmd := cw.cmd
+	cw.Unlock()
+	return cmd.Wait()
 }

--- a/justrun.go
+++ b/justrun.go
@@ -66,11 +66,7 @@ func main() {
 		argError("no file paths provided to watch")
 	}
 
-	cmd := &cmdReloader{
-		cond:           &sync.Cond{L: new(sync.Mutex)},
-		command:        *command,
-		waitForCommand: *waitForCommand,
-	}
+	cmd := &cmdWrapper{Mutex: new(sync.Mutex), command: *command, cmd: nil}
 
 	sigCh := make(chan os.Signal)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
@@ -83,16 +79,12 @@ func main() {
 	}
 
 	wasDelayed := false
-
-	lastStartTime := time.Now()
-	cmd.Reload()
+	done := make(chan error) // first instance is unused but needed for now
+	lastStartTime, done := reload(cmd, done)
 	tick := time.NewTicker(*delayDur)
 	for {
 		select {
-		case ev, ok := <-cmdCh:
-			if !ok {
-				return
-			}
+		case ev := <-cmdCh:
 			if lastStartTime.After(ev.Time) {
 				continue
 			}
@@ -104,27 +96,79 @@ func main() {
 				continue
 			}
 			wasDelayed = false
-			lastStartTime = time.Now()
-			cmd.Reload()
-			tick.Stop()
+			lastStartTime, done = reload(cmd, done)
 			tick = time.NewTicker(*delayDur)
 		case <-tick.C:
 			if wasDelayed {
 				wasDelayed = false
-				lastStartTime = time.Now()
-				cmd.Reload()
+				lastStartTime, done = reload(cmd, done)
 			}
 		}
 	}
 }
 
-func waitForInterrupt(sigCh chan os.Signal, cmd *cmdReloader) {
-	for range sigCh {
-		go func() {
-			cmd.Terminate()
-			os.Exit(0)
-		}()
+func reload(cmd *cmdWrapper, done chan error) (time.Time, chan error) {
+	if cmd.cmd != nil {
+		// If there's something to shut down, shut it down.
+		shutdownCommand(cmd, done)
 	}
+	lastStartTime := time.Now()
+	return lastStartTime, runCommand(cmd)
+}
+
+func runCommand(cmd *cmdWrapper) chan error {
+	log.Printf("running '%s'\n", *command)
+	err := cmd.Start()
+	if err != nil {
+		log.Printf("command failed: %s", err)
+		return nil
+	}
+	done := make(chan error)
+	if *waitForCommand {
+		err := cmd.Wait()
+		go func() { done <- err }()
+		return done
+	}
+	go func() {
+		err := cmd.Wait()
+		done <- err
+	}()
+	return done
+}
+
+func shutdownCommand(cmd *cmdWrapper, done chan error) {
+	err := cmd.Terminate()
+	if err == syscall.ESRCH {
+		return
+	}
+
+	// Done is sent to after the command's Wait call returns. But it's really a
+	// latency optimization (or spin-loop prevention) over polling the process
+	// with Terminate until the process stops existing (when syscall.ESRCH
+	// will be returned).
+	for err != syscall.ESRCH {
+		select {
+		case <-done:
+			break
+		case <-time.After(300 * time.Millisecond):
+			err = cmd.Terminate()
+		}
+	}
+	msg := "terminating current command"
+	if *verbose {
+		msg += fmt.Sprintf(" %d", cmd.cmd.Process.Pid)
+	}
+	log.Println(msg)
+}
+
+func waitForInterrupt(sigCh chan os.Signal, cmd *cmdWrapper) {
+	<-sigCh
+	done := make(chan error)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	shutdownCommand(cmd, done)
+	os.Exit(0)
 }
 
 type pathsFlag []string

--- a/watch.go
+++ b/watch.go
@@ -118,14 +118,9 @@ func listenForEvents(w *fsnotify.Watcher, cmdCh chan<- event, ignorer Ignorer) {
 				Time:  time.Now(),
 				Event: ev,
 			}
-		case err, ok := <-w.Errors:
-			if !ok {
-				close(cmdCh)
-				return
-			}
+		case err := <-w.Errors:
 			// w.Close causes this.
 			if err == nil {
-				close(cmdCh)
 				return
 			}
 			log.Println("watch error:", err)


### PR DESCRIPTION
This reverts commit 6ead992af453883b10a0e72a31e8d6ec62b13f2b.

This doesn't work right because we don't clear out waitFinished but the obvious
change to that doesn't work because it involves waiting on the Cond's lock in
Reload while we already hold it.

Updates #15