### PR TITLE
handle data races by adding a reloader, try #2

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -118,9 +118,14 @@ func listenForEvents(w *fsnotify.Watcher, cmdCh chan<- event, ignorer Ignorer) {
 				Time:  time.Now(),
 				Event: ev,
 			}
-		case err := <-w.Errors:
+		case err, ok := <-w.Errors:
+			if !ok {
+				close(cmdCh)
+				return
+			}
 			// w.Close causes this.
 			if err == nil {
+				close(cmdCh)
 				return
 			}
 			log.Println("watch error:", err)


### PR DESCRIPTION
This is the second attempt at this.

This cmdReloader does a better job of tracking the state of the process started
by justrun than previous code. It's main purpose here is to prevent reloads (new
process creation) when the user attempts to interrupt the justrun process (with
`ctrl-C` or similar signals).

The previous version of this patch (#18, reverted in #21) didn't wait
for waitFinished and waitErr to be correctly set after attempting to
terminate the process. This version does.

Fixes #15