### PR TITLE
Use sh instead of bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Usage
       -stdin=false: read list of files to track from stdin, not the command-line
       -v=false: verbose output
       -w=false: wait for the command to finish and do not attempt to kill it
+      -s=bash: shell to run the command
 
 
 Compared to other tools

--- a/cmdwrap.go
+++ b/cmdwrap.go
@@ -19,7 +19,7 @@ type cmdWrapper struct {
 // sets it as the wrapped command. If exec.Cmd.Start returns an error, the
 // last wrapped cmd will be left in place.
 func (cw *cmdWrapper) Start() error {
-	cmd := exec.Command("bash", "-c", *command)
+	cmd := exec.Command("sh", "-c", *command)
 	// Necessary so that the SIGTERM's in Terminate will traverse down to the
 	// the child processes in the bash command above.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/justrun.go
+++ b/justrun.go
@@ -18,6 +18,7 @@ var (
 	help           = flag.Bool("help", false, "print this help text")
 	h              = flag.Bool("h", false, "print this help text")
 	command        = flag.String("c", "", "command to run when files change in given directories")
+	shell          = flag.String("s", "sh", "shell to run the command")
 	ignoreFlag     pathsFlag
 	stdin          = flag.Bool("stdin", false, "read list of files to track from stdin, not the command-line")
 	waitForCommand = flag.Bool("w", false, "wait for the command to finish and do not attempt to kill it")
@@ -69,6 +70,7 @@ func main() {
 	cmd := &cmdReloader{
 		cond:           &sync.Cond{L: new(sync.Mutex)},
 		command:        *command,
+		shell:          *shell,
 		waitForCommand: *waitForCommand,
 	}
 


### PR DESCRIPTION
In docker containers based on busybox  images I get `command failed: exec: "bash": executable file not found in $PATH`. So I think it is better to `/bin/sh`

`/bin/sh` point to `/bin/bash|/bin/dash|bin/busybox` on most GNU/Linux systems 