### PR TITLE
go.mod: update fsnotify to v1.4.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/jmhodges/justrun
 
 go 1.13
 
-require (
-	github.com/fsnotify/fsnotify v1.4.3-0.20170329110642-4da3e2cfbabc
-	golang.org/x/sys v0.0.0-20170427041856-9ccfe848b9db // indirect
-)
+require github.com/fsnotify/fsnotify v1.4.8-0.20191012010759-4bf2d1fec783

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/fsnotify/fsnotify v1.4.3-0.20170329110642-4da3e2cfbabc h1:omfZI1v/Bu4YEatmRAYKISWA95u6XiN4Zorz/JPKCZA=
-github.com/fsnotify/fsnotify v1.4.3-0.20170329110642-4da3e2cfbabc/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-golang.org/x/sys v0.0.0-20170427041856-9ccfe848b9db h1:znurcNjtwV7XblDOBERYCP1TUjpwbp8bi3Szx8gbNBE=
-golang.org/x/sys v0.0.0-20170427041856-9ccfe848b9db/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+github.com/fsnotify/fsnotify v1.4.8-0.20191012010759-4bf2d1fec783 h1:SmsgwFZy9pdTk/k8BZz40D3P5umP5+Ejt3hAi0paBNQ=
+github.com/fsnotify/fsnotify v1.4.8-0.20191012010759-4bf2d1fec783/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
It seems there were some useful fixes in release 1.4.7, at the very
least - the CHANGELOG mentions several races and deadlocks that were
fixed. I have been using v1.4.8 without issue for a few weeks now.
https://github.com/fsnotify/fsnotify/blob/master/CHANGELOG.md

Updating fsnotify in go.mod and then running "go get ./..." removed
the x/sys dependency; I'm happy to add it back.

Here is the full diff:

https://github.com/fsnotify/fsnotify/compare/4da3e2cfbabc...4bf2d1fec783