### PR TITLE
bump to Go 1.26.3 and use it in Github Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
       - run: go test -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmhodges/justrun
 
-go 1.21
+go 1.26.3
 
 require github.com/fsnotify/fsnotify v1.9.0
 


### PR DESCRIPTION
Bumps to Go 1.26.3 in the go.mod and (since GHA currently only has Go
1.24.2), uses the go.mod for the Go version to run with.
